### PR TITLE
revert: "ci: Trigger on pull-request generated by Release Please"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches-ignore:
       - main
-  pull_request:
-    branches:
-      - 'release-please*'
 
 jobs:
   ansible-lint:


### PR DESCRIPTION
Seems triggering Github actions is prohibited if git action is done with GITHUB_TOKEN.

This reverts commit 14bb2b6de2fe7a3e791cb1005cb2e0d9df614365.